### PR TITLE
Conditionally disable & polyfill to add .NET standard 2.1 support

### DIFF
--- a/examples/Blackboard/Blackboard.csproj
+++ b/examples/Blackboard/Blackboard.csproj
@@ -2,10 +2,9 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Copy native library from Iceoryx2 output directory -->

--- a/examples/Blackboard/Blackboard.csproj
+++ b/examples/Blackboard/Blackboard.csproj
@@ -2,9 +2,10 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
+    <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1</TargetFrameworks>
   </PropertyGroup>
 
   <!-- Copy native library from Iceoryx2 output directory -->

--- a/src/Iceoryx2.Reactive/Iceoryx2.Reactive.csproj
+++ b/src/Iceoryx2.Reactive/Iceoryx2.Reactive.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1</TargetFrameworks>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <LangVersion>latest</LangVersion>

--- a/src/Iceoryx2/Blackboard/BlackboardServiceBuilder.cs
+++ b/src/Iceoryx2/Blackboard/BlackboardServiceBuilder.cs
@@ -83,7 +83,14 @@ public sealed class BlackboardServiceBuilder<TKey> : IDisposable
     /// <exception cref="ArgumentException">Thrown when serviceName is empty or whitespace.</exception>
     public unsafe Result<BlackboardService<TKey>, Iox2Error> Open(string serviceName)
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(serviceName);
+#else
+        if (serviceName is null)
+        {
+            throw new ArgumentNullException(nameof(serviceName));
+        }
+#endif
         if (string.IsNullOrWhiteSpace(serviceName))
         {
             throw new ArgumentException("Service name cannot be empty or whitespace.", nameof(serviceName));
@@ -176,8 +183,20 @@ public sealed class BlackboardServiceBuilder<TKey> : IDisposable
         IEnumerable<BlackboardEntry<TKey, TValue>> entries)
         where TValue : unmanaged
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(serviceName);
         ArgumentNullException.ThrowIfNull(entries);
+#else
+        if (serviceName is null)
+        {
+            throw new ArgumentNullException(nameof(serviceName));
+        }
+
+        if (entries is null)
+        {
+            throw new ArgumentNullException(nameof(entries));
+        }
+#endif
 
         if (string.IsNullOrWhiteSpace(serviceName))
         {

--- a/src/Iceoryx2/Extensions/Iox2LoggingExtensions.cs
+++ b/src/Iceoryx2/Extensions/Iox2LoggingExtensions.cs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
 
 using Microsoft.Extensions.Logging;
 using System;

--- a/src/Iceoryx2/Extensions/ServiceCollectionExtensions.cs
+++ b/src/Iceoryx2/Extensions/ServiceCollectionExtensions.cs
@@ -10,7 +10,7 @@
 //
 // SPDX-License-Identifier: Apache-2.0 OR MIT
 
-#if NET6_0_OR_GREATER
+#if NET6_0_OR_GREATER || NETSTANDARD2_1
 
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;

--- a/src/Iceoryx2/Iceoryx2.csproj
+++ b/src/Iceoryx2/Iceoryx2.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net8.0;net9.0;net10.0</TargetFrameworks>
+    <TargetFrameworks>net8.0;net9.0;net10.0;netstandard2.1</TargetFrameworks>
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
@@ -60,6 +60,10 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
+    <PackageReference Include="PolySharp" Version="1.16.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
   </ItemGroup>
 
   <!-- Copy native library to output directory of any project referencing this library -->

--- a/src/Iceoryx2/Iceoryx2.csproj
+++ b/src/Iceoryx2/Iceoryx2.csproj
@@ -60,10 +60,6 @@
   <ItemGroup>
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="8.0.0" />
-    <PackageReference Include="PolySharp" Version="1.16.0">
-      <PrivateAssets>all</PrivateAssets>
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-    </PackageReference>
   </ItemGroup>
 
   <!-- Copy native library to output directory of any project referencing this library -->

--- a/src/Iceoryx2/Native/CallbackContext.cs
+++ b/src/Iceoryx2/Native/CallbackContext.cs
@@ -51,7 +51,14 @@ internal static class CallbackContext
     /// </summary>
     public static IntPtr Pin<T>(T state) where T : class
     {
+#if NET6_0_OR_GREATER
         ArgumentNullException.ThrowIfNull(state);
+#else
+        if (state is null)
+        {
+            throw new ArgumentNullException(nameof(state));
+        }
+#endif
         var handle = GCHandle.Alloc(state, GCHandleType.Normal);
         return GCHandle.ToIntPtr(handle);
     }

--- a/src/Iceoryx2/Native/Iox2NativeMethods.cs
+++ b/src/Iceoryx2/Native/Iox2NativeMethods.cs
@@ -33,6 +33,9 @@ internal static partial class Iox2NativeMethods
     // Cross-Platform Library Loading
     // ========================================
 
+    // netstandard2.1 has no NativeLibrary resolver API; there the runtime's default
+    // DllImport probing (lib prefix + platform extension) resolves the library.
+#if NET6_0_OR_GREATER
     static Iox2NativeMethods()
     {
         NativeLibrary.SetDllImportResolver(typeof(Iox2NativeMethods).Assembly, DllImportResolver);
@@ -60,6 +63,7 @@ internal static partial class Iox2NativeMethods
 
         return IntPtr.Zero;
     }
+#endif
 
     // ========================================
     // Constants

--- a/src/Iceoryx2/Sample.cs
+++ b/src/Iceoryx2/Sample.cs
@@ -135,7 +135,7 @@ public sealed class Sample<T> : IDisposable where T : unmanaged
         if (payloadPtr == IntPtr.Zero)
             throw new InvalidOperationException("Failed to get sample payload");
 
-        return ref System.Runtime.CompilerServices.Unsafe.AsRef<T>(payloadPtr.ToPointer());
+        return ref *(T*)payloadPtr.ToPointer();
     }
 
     /// <summary>
@@ -168,7 +168,7 @@ public sealed class Sample<T> : IDisposable where T : unmanaged
         if (payloadPtr == IntPtr.Zero)
             throw new InvalidOperationException("Failed to get sample payload");
 
-        return ref System.Runtime.CompilerServices.Unsafe.AsRef<T>(payloadPtr.ToPointer());
+        return ref *(T*)payloadPtr.ToPointer();
     }
 
     /// <summary>

--- a/src/Iceoryx2/WaitSet.cs
+++ b/src/Iceoryx2/WaitSet.cs
@@ -46,9 +46,17 @@ public sealed class WaitSet : IDisposable
             }
         };
 
-    private sealed record WaitSetRunContext(
-        Func<WaitSetAttachmentId, CallbackProgression> Callback,
-        bool DisposeAttachments);
+    private sealed class WaitSetRunContext
+    {
+        public WaitSetRunContext(Func<WaitSetAttachmentId, CallbackProgression> callback, bool disposeAttachments)
+        {
+            Callback = callback;
+            DisposeAttachments = disposeAttachments;
+        }
+
+        public Func<WaitSetAttachmentId, CallbackProgression> Callback { get; }
+        public bool DisposeAttachments { get; }
+    }
 
     private static readonly Native.Iox2NativeMethods.iox2_waitset_run_callback s_runCallbackTrampoline =
         (attachmentIdHandle, contextPtr) =>


### PR DESCRIPTION
This PR adds support for .NET Standard 2.1, allowing Unity applications to use Iceoryx2. This is comprised of two main changes:
* #if-ing out ArgumentNullException.ThrowIfNull and switching to the older `if (... is null) throw new ArgumentNullException` form if the version doesn't support `ThrowIfNull`. 
* Adding netstandard2.1 as a target.
* Adding PolySharp to source transform away features that are too new.

